### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AzuanyMila/c535fbb7-5015-4d0d-872d-8c383cd77a50/9d8b4d26-1350-4f30-9169-6601940a3c50/_apis/work/boardbadge/dd59c832-28f8-4541-9160-ed7ec38cc101)](https://dev.azure.com/AzuanyMila/c535fbb7-5015-4d0d-872d-8c383cd77a50/_boards/board/t/9d8b4d26-1350-4f30-9169-6601940a3c50/Microsoft.RequirementCategory)
 # Projects
 
 Here are some of my projects


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AzuanyMila/c535fbb7-5015-4d0d-872d-8c383cd77a50/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.